### PR TITLE
Bump Gitea 1.25.5 → 1.26.1; start-sdk 1.3.3 → 1.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
-## How the upstream version is pulled
-- dockerTag in `startos/manifest/index.ts`: `gitea/gitea:<version>`
+# CLAUDE.md
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the doc map and contribution workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,36 @@
 # Contributing
 
-## Building and Development
+This repo packages [Gitea](https://github.com/go-gitea/gitea) for StartOS.
 
-See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for complete environment setup and build instructions.
+## Documentation — keep it in sync
 
-### Quick Start
+- **`README.md`** — what this package is and how it's built (image, volumes, interfaces). For developers and AI assistants.
+- **`instructions.md`** — the user-facing instructions packed into the `.s9pk` and shown on the **Instructions** tab in StartOS, for the person running the service.
+- **`CONTRIBUTING.md`** — this file.
+- **`CLAUDE.md`** — operating rules for AI developers working in this repo.
+
+**Any code change that warrants it must update `README.md` and `instructions.md` in the same change** — a new or renamed action, an added or removed volume / port / interface / dependency, a changed default, a new limitation, any altered user-visible behavior. Don't defer: a package that ships with a stale README or stale instructions is not done, even if the code is perfect. Content rules live in the packaging guide: [Writing READMEs](https://docs.start9.com/packaging/writing-readmes.html) and [Writing Service Instructions](https://docs.start9.com/packaging/writing-instructions.html).
+
+## Building
+
+See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for environment setup, then:
 
 ```bash
-# Install dependencies
-npm ci
-
-# Build universal package
-make
+npm ci    # install dependencies
+make      # build the universal .s9pk
 ```
 
-## How to Contribute
+## Updating the upstream version
 
-1. Fork the repository and create a branch from `master`
-2. Make your changes
-3. Open a pull request to `master`
+Gitea runs the upstream `gitea/gitea` image unmodified — there is no custom Dockerfile and no source build. To track a new upstream release:
+
+1. Bump `dockerTag` in `startos/manifest/index.ts` to `gitea/gitea:<new version>`.
+2. Update `version` and `releaseNotes` in the file under `startos/versions/`, renaming it to the new version string. A *new* version file is only needed when the bump carries an `up`/`down` migration, or when you want the old release notes preserved in git history — see [Versions](https://docs.start9.com/packaging/versions.html).
+3. Rebuild (`make`), sideload the `.s9pk`, and confirm it starts.
+4. Review `README.md` and `instructions.md` for anything the bump changed.
+
+## How to contribute
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes — including the doc updates above.
+3. Open a pull request to `master`.

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,40 @@
+# Gitea
+
+## Documentation
+
+- [Gitea documentation](https://gitea.com/gitea/docs) — upstream reference covering repositories, organizations, the admin panel, Gitea Actions, the API, and `app.ini` settings.
+
+## What you get on StartOS
+
+- A **Web UI and git (HTTP)** interface — the Gitea web app, and the endpoint for cloning, pushing, and pulling over HTTP.
+- A **git (SSH)** interface (user `git`) for cloning, pushing, and pulling over SSH.
+- An embedded SQLite database stored alongside repositories and LFS objects in a single managed volume — no separate database to install or configure.
+
+## Getting set up
+
+On first start Gitea posts a **Create Admin User** task. Until you complete it, the service has no administrator.
+
+1. Run the **Create Admin User** task. Provide a username and email. A strong password is generated and shown once — copy it before dismissing the result. If you lose it later, run **Reset Admin Password**.
+2. Sign in to the Web UI with those credentials.
+3. If you plan to send emails (notifications, invitations, password resets), run **Configure SMTP** and pick either your StartOS system SMTP or custom credentials.
+
+## Using Gitea
+
+### Web UI and git over HTTP
+
+Open the **Web UI and git (HTTP)** interface to reach the Gitea web app. The same hostnames serve git over HTTP, so you can clone, push, and pull using the URLs Gitea shows on each repository page.
+
+### git over SSH
+
+Open the **git (SSH)** interface to see the SSH host and port. Add your SSH public key under your Gitea user settings, then use the `git@…` URLs Gitea generates on each repository page.
+
+### Actions
+
+- **Set Primary Url** — pick which of the available HTTP URLs Gitea uses when generating clone URLs, links in emails, OAuth callbacks, and so on. Switch this whenever you add or change a domain you want users to see.
+- **Enable / Disable Registrations** — toggle whether anyone with your Gitea URL can create an account. Registrations are disabled by default; enabling them is a public-signup decision, so the action confirms it with a warning.
+- **Configure SMTP** — set the credentials Gitea uses to send mail. Choose your StartOS system SMTP or supply a custom host, port, from-address, username, and password.
+- **Reset Admin Password** — pick an existing admin user and generate a new password for them. Use this to rotate the password or to recover an account whose password you've lost.
+
+### Large file storage
+
+Git LFS is enabled and stored alongside your repositories in the managed volume. Enable LFS per repository in its settings; use the Git LFS client on the pushing machine as you would with upstream Gitea.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gitea-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.0"
+        "@start9labs/start-sdk": "1.5.1"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
-      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
+      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -342,6 +342,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gitea-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3"
+        "@start9labs/start-sdk": "1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
-      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -71,12 +71,12 @@
         "@noble/hashes": "^1.8.0",
         "@types/ini": "^4.1.1",
         "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
+        "fast-xml-parser": "~5.7.0",
         "ini": "^5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       }
     },
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -127,13 +127,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -142,8 +143,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -230,9 +231,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -246,9 +247,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -306,10 +307,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -326,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3"
+    "@start9labs/start-sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.0"
+    "@start9labs/start-sdk": "1.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -9,7 +9,6 @@ export const manifest = setupManifest({
   upstreamRepo: 'https://github.com/go-gitea/gitea',
   marketingUrl: 'https://gitea.com/',
   donationUrl: null,
-  docsUrls: ['https://gitea.com/gitea/docs'],
   description: { short, long },
   volumes: ['main'],
   images: {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     gitea: {
       source: {
-        dockerTag: 'gitea/gitea:1.25.5',
+        dockerTag: 'gitea/gitea:1.26.1',
       },
       arch: ['x86_64', 'aarch64', 'riscv64'],
     },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_1_25_5_3 } from './v1.25.5.3'
+import { v_1_26_1 } from './v1.26.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_25_5_3,
+  current: v_1_26_1,
   other: [],
 })

--- a/startos/versions/v1.26.1.ts
+++ b/startos/versions/v1.26.1.ts
@@ -4,14 +4,29 @@ import { getHttpInterfaceUrls, getSecretKey } from '../utils'
 import { storeJson } from '../fileModels/store.json'
 import { sdk } from '../sdk'
 
-export const v_1_25_5_3 = VersionInfo.of({
-  version: '1.25.5:3',
+export const v_1_26_1 = VersionInfo.of({
+  version: '1.26.1:1',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.3.3)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.3.3)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.3.3)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.3.3)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.3.3)',
+    en_US: `**Bumps**
+
+- Gitea → 1.26.1
+- start-sdk → 1.5.0`,
+    es_ES: `**Cambios de versión**
+
+- Gitea → 1.26.1
+- start-sdk → 1.5.0`,
+    de_DE: `**Versionssprünge**
+
+- Gitea → 1.26.1
+- start-sdk → 1.5.0`,
+    pl_PL: `**Zmiany wersji**
+
+- Gitea → 1.26.1
+- start-sdk → 1.5.0`,
+    fr_FR: `**Mises à niveau**
+
+- Gitea → 1.26.1
+- start-sdk → 1.5.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- **Upstream**: Gitea `1.25.5` → `1.26.1` (minor + patch). Bumps the docker tag only; this package uses the upstream image unmodified and none of its env-locked settings (`GITEA__server__ROOT_URL`, `GITEA__security__SECRET_KEY/INSTALL_LOCK`, `GITEA__service__DISABLE_REGISTRATION`, `GITEA__lfs__PATH`, `GITEA__mailer__*`) changed semantics in 1.26.
- **SDK**: `@start9labs/start-sdk` `1.3.3` → `1.5.0`. `npm run check` is clean; no API surface used here changed.
- **deps**: `npm update` picked up routine sub-dep refreshes.
- **version file**: renamed `v1.25.5.3.ts` → `v1.26.1.ts` in place (`1.26.1:1`). No new migration; the legacy `start9/config.yaml` → `store.json` migration retained (idempotent — early-returns when no legacy config is present).
- **README**: reviewed; nothing user-visible changed, README is version-agnostic, no update needed.

## Upstream scrutiny (1.26.0 changelog)

Reviewed BREAKING entries; none affect the StartOS package:
- `PUBLIC_URL_DETECTION` default → `auto`: StartOS sets `ROOT_URL` explicitly, so detection isn't relied upon.
- `X_FRAME_OPTIONS` moved from `[cors]` → `[security]`: not configured by this package.
- `Remove GET API /admin/runners/registration-token`, `concurrency` action syntax, swagger annotation tightening: don't touch wrapper code.

1.26 also ships a long list of new user-facing features (terraform registry, instance banner / maintenance mode, OpenAPI spec rendering, OIDC RP-initiated logout, action workflow dependency graph, user badges, configurable Actions token perms, etc.) — all consumed through Gitea's own admin UI / `app.ini`, no wrapper plumbing required.

## Test plan

- [x] `npm install` clean.
- [x] `npm run check` clean.
- [x] `make` builds `.s9pk` for x86_64, aarch64, riscv64.
- [ ] Install / upgrade smoke test on a StartOS instance (deferred; runtime testing not required per current workflow).

_Replaces #37 (auto-closed when its head branch was renamed)._
