### PR TITLE
chore: bump start-sdk 1.5.0 → 1.5.2 (1.26.1:2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gitea-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -342,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1"
+    "@start9labs/start-sdk": "1.5.2"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_1_26_1 } from './v1.26.1'
+import { v_1_26_1_2 } from './v1.26.1_2'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_26_1,
+  current: v_1_26_1_2,
   other: [],
 })

--- a/startos/versions/v1.26.1_2.ts
+++ b/startos/versions/v1.26.1_2.ts
@@ -4,29 +4,29 @@ import { getHttpInterfaceUrls, getSecretKey } from '../utils'
 import { storeJson } from '../fileModels/store.json'
 import { sdk } from '../sdk'
 
-export const v_1_26_1 = VersionInfo.of({
-  version: '1.26.1:1',
+export const v_1_26_1_2 = VersionInfo.of({
+  version: '1.26.1:2',
   releaseNotes: {
     en_US: `**Bumps**
 
 - Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     es_ES: `**Cambios de versión**
 
 - Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     de_DE: `**Versionssprünge**
 
 - Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     pl_PL: `**Zmiany wersji**
 
 - Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     fr_FR: `**Mises à niveau**
 
 - Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.5.0 → 1.5.2 and the package revision to `1.26.1:2`.
- Upstream Gitea is already at the latest release (1.26.1) — no image change.

## SDK changelog (1.5.1 + 1.5.2)

- **1.5.2** — fixes `Backups.withPgDump` / `Backups.withMysqlDump` writing empty dump files through the `backup-fs` FUSE mount (staged through `/tmp` and `cp`'d).
- **1.5.1** — `GetActionInputType` now matches `ActionInfo` instead of `Action` (was collapsing to `never`); `BindOptions.addSsl` is `Partial<AddSslOptions>` on non-SSL protocols.

None of these affect gitea-startos directly — backups here use `Backups.ofVolumes('main')`, not the SQL dump helpers, and the package doesn't use `TaskOptions`/`addSsl`. The bump is purely mechanical.

## Test plan

- [x] `make` green for `x86_64`, `aarch64`, `riscv64`.
- [x] `npm run check` (tsc --noEmit) passes under the new SDK.