### PR TITLE
chore: bump Gitea to 1.26.2; bump start-sdk to 1.5.3; 1.26.1:1 → 1.26.2:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gitea-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.3"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.3.tgz",
+      "integrity": "sha512-OyHe9J6hMvyA5ZavcLkxdVQvZcuTH9J9kagV6NDI83eAG/YpJFIq62gP/n/2PPNdHWwNSXVQmSwnsvsV8Gyg+A==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -342,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1"
+    "@start9labs/start-sdk": "1.5.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     gitea: {
       source: {
-        dockerTag: 'gitea/gitea:1.26.1',
+        dockerTag: 'gitea/gitea:1.26.2',
       },
       arch: ['x86_64', 'aarch64', 'riscv64'],
     },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_1_26_1 } from './v1.26.1'
+import { v_1_26_2 } from './v1.26.2'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_26_1,
+  current: v_1_26_2,
   other: [],
 })

--- a/startos/versions/v1.26.2.ts
+++ b/startos/versions/v1.26.2.ts
@@ -4,29 +4,29 @@ import { getHttpInterfaceUrls, getSecretKey } from '../utils'
 import { storeJson } from '../fileModels/store.json'
 import { sdk } from '../sdk'
 
-export const v_1_26_1 = VersionInfo.of({
-  version: '1.26.1:1',
+export const v_1_26_2 = VersionInfo.of({
+  version: '1.26.2:0',
   releaseNotes: {
     en_US: `**Bumps**
 
-- Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- Gitea → 1.26.2
+- start-sdk → 1.5.3`,
     es_ES: `**Cambios de versión**
 
-- Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- Gitea → 1.26.2
+- start-sdk → 1.5.3`,
     de_DE: `**Versionssprünge**
 
-- Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- Gitea → 1.26.2
+- start-sdk → 1.5.3`,
     pl_PL: `**Zmiany wersji**
 
-- Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- Gitea → 1.26.2
+- start-sdk → 1.5.3`,
     fr_FR: `**Mises à niveau**
 
-- Gitea → 1.26.1
-- start-sdk → 1.5.0`,
+- Gitea → 1.26.2
+- start-sdk → 1.5.3`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- **Gitea 1.26.1 → 1.26.2** — security + bugfix release on the 1.26.x line ([upstream notes](https://github.com/go-gitea/gitea/releases/tag/v1.26.2)). Highlights: token-scope enforcement on raw/media/attachment downloads, PKCE / refresh-token hardening, OAuth client-request binding, encrypted AWS creds, plus a long list of actions / pull-request / packages bug fixes. Wrapped via the upstream `gitea/gitea:1.26.2` Docker image.
- **start-sdk 1.5.1 → 1.5.3** — patch bumps, no surface changes that affect this package; picked up via `npm install` + `npm update`.
- StartOS version: **1.26.1:1 → 1.26.2:0** (new upstream version resets revision to `:0`). Renamed `startos/versions/v1.26.1.ts` → `v1.26.2.ts` in place (no migration added; the existing legacy-config `up` migration is still a no-op for already-migrated installs and is preserved for users upgrading from pre-1.26.1).

## Test plan

- [x] `npm install` / `npm update` clean, `npx tsc --noEmit` passes.
- [x] `make` builds `gitea_{x86_64,aarch64,riscv64}.s9pk` with SDK 1.5.3 and version `1.26.2:0`.
- [x] Fresh sideload-install of `gitea_x86_64.s9pk` onto a `startos-beta-9` VM, then `package start gitea` — service comes up, health check `Web Interface` reports `success` ("Gitea is ready"), `/api/healthz` 200s, no errors in the post-startup logs.