### PR TITLE
fix: pin unique session cookie name (i_like_gitea)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These settings are controlled exclusively through StartOS actions and cannot be 
 | Secret key | `GITEA__security__SECRET_KEY` | Auto-generated at install, stored in `store.json` |
 | User registration | `GITEA__service__DISABLE_REGISTRATION` | "Enable/Disable Registrations" action |
 | LFS path | `GITEA__lfs__PATH` | Always `/data/git/lfs` (hardcoded) |
+| Session cookie name | `GITEA__session__COOKIE_NAME` | Always `i_like_gitea` (hardcoded) — avoids cookie collisions with other services on the same local hostname |
 | SMTP/mailer | `GITEA__mailer__*` | "Configure SMTP" action |
 
 ### Settings NOT managed by StartOS
@@ -296,6 +297,7 @@ startos_managed_env_vars:
   - GITEA__security__SECRET_KEY
   - GITEA__service__DISABLE_REGISTRATION
   - GITEA__lfs__PATH
+  - GITEA__session__COOKIE_NAME
   - GITEA__mailer__ENABLED
   - GITEA__mailer__SMTP_ADDR
   - GITEA__mailer__SMTP_PORT

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -82,6 +82,10 @@ export const main = sdk.setupMain(async ({ effects }) => {
     ),
     GITEA__security__INSTALL_LOCK: 'true',
     GITEA__security__SECRET_KEY,
+    // Gitea's default session cookie is the generic `session`, which collides
+    // with other services on the same StartOS LAN host (cookies are host-scoped,
+    // port-agnostic). Pin a unique name so a stale cookie can't 500 the login.
+    GITEA__session__COOKIE_NAME: 'i_like_gitea',
     ...(mailer || {}),
   }
 
@@ -161,6 +165,7 @@ type GiteaEnv = GiteaMailer & {
   GITEA__server__SSH_PORT?: string
   GITEA__security__INSTALL_LOCK: 'true'
   GITEA__security__SECRET_KEY: string
+  GITEA__session__COOKIE_NAME: 'i_like_gitea'
   GITEA__service__DISABLE_REGISTRATION: string
 }
 

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -5,28 +5,23 @@ import { storeJson } from '../fileModels/store.json'
 import { sdk } from '../sdk'
 
 export const current = VersionInfo.of({
-  version: '1.26.2:0',
+  version: '1.26.2:1',
   releaseNotes: {
-    en_US: `**Bumps**
+    en_US: `**Improvements**
 
-- Gitea → 1.26.2
-- start-sdk → 1.5.3`,
-    es_ES: `**Cambios de versión**
+- Use a unique session cookie name (\`i_like_gitea\`) instead of the generic \`session\`, preventing login errors when other services share the same local hostname. You may need to sign in again after updating.`,
+    es_ES: `**Mejoras**
 
-- Gitea → 1.26.2
-- start-sdk → 1.5.3`,
-    de_DE: `**Versionssprünge**
+- Se usa un nombre único para la cookie de sesión (\`i_like_gitea\`) en lugar del genérico \`session\`, evitando errores de inicio de sesión cuando otros servicios comparten el mismo nombre de host local. Es posible que debas iniciar sesión de nuevo tras la actualización.`,
+    de_DE: `**Verbesserungen**
 
-- Gitea → 1.26.2
-- start-sdk → 1.5.3`,
-    pl_PL: `**Zmiany wersji**
+- Es wird ein eindeutiger Name für das Sitzungs-Cookie (\`i_like_gitea\`) anstelle des generischen \`session\` verwendet, um Anmeldefehler zu vermeiden, wenn andere Dienste denselben lokalen Hostnamen nutzen. Nach dem Update musst du dich möglicherweise erneut anmelden.`,
+    pl_PL: `**Ulepszenia**
 
-- Gitea → 1.26.2
-- start-sdk → 1.5.3`,
-    fr_FR: `**Mises à niveau**
+- Używana jest unikalna nazwa ciasteczka sesji (\`i_like_gitea\`) zamiast ogólnej \`session\`, co zapobiega błędom logowania, gdy inne usługi współdzielą tę samą lokalną nazwę hosta. Po aktualizacji może być konieczne ponowne zalogowanie.`,
+    fr_FR: `**Améliorations**
 
-- Gitea → 1.26.2
-- start-sdk → 1.5.3`,
+- Utilisation d'un nom unique pour le cookie de session (\`i_like_gitea\`) au lieu du générique \`session\`, évitant les erreurs de connexion lorsque d'autres services partagent le même nom d'hôte local. Vous devrez peut-être vous reconnecter après la mise à jour.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Pin a unique session cookie name so Gitea stops using the generic `session` cookie, which collides with other services on the same StartOS LAN host.

- Set `GITEA__session__COOKIE_NAME = i_like_gitea`. On StartOS, every service is reached on the LAN as `<host>.local:<port>`, and browser cookies are host-scoped and ignore the port — so Gitea's default generic `session` cookie collides with any other service (or a prior install) on the same host. A stale `session` cookie 500s the login when Gitea regenerates the session (invalid sid length); a unique name avoids it.
- Bumps the package revision `1.26.2:0` → `1.26.2:1`. Existing users may need to sign in again after updating (cookie name change).

Mirrors the same change in `forgejo-startos` (`i_like_forgejo`) to keep the two packages aligned.

Verified on a StartOS box: builds as `v1.26.2:1`, boots healthy (`/api/healthz` 200), and the generated `app.ini` shows `[session] COOKIE_NAME = i_like_gitea`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)