### PR TITLE
chore: bump Gitea to 1.26.4; 1.26.2:1 → 1.26.4:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,6 +105,18 @@
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
@@ -216,9 +228,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
+      "integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
       "funding": [
         {
           "type": "github",
@@ -231,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -247,16 +259,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     gitea: {
       source: {
-        dockerTag: 'gitea/gitea:1.26.2',
+        dockerTag: 'gitea/gitea:1.26.4',
       },
       arch: ['x86_64', 'aarch64', 'riscv64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -5,23 +5,83 @@ import { storeJson } from '../fileModels/store.json'
 import { sdk } from '../sdk'
 
 export const current = VersionInfo.of({
-  version: '1.26.2:1',
+  version: '1.26.4:0',
   releaseNotes: {
-    en_US: `**Improvements**
+    en_US: `Updated Gitea to 1.26.4.
 
-- Use a unique session cookie name (\`i_like_gitea\`) instead of the generic \`session\`, preventing login errors when other services share the same local hostname. You may need to sign in again after updating.`,
-    es_ES: `**Mejoras**
+**Security**
 
-- Se usa un nombre único para la cookie de sesión (\`i_like_gitea\`) en lugar del genérico \`session\`, evitando errores de inicio de sesión cuando otros servicios comparten el mismo nombre de host local. Es posible que debas iniciar sesión de nuevo tras la actualización.`,
-    de_DE: `**Verbesserungen**
+- Disabled users are no longer auto-reactivated on OAuth2 login, plus several LFS, host-matcher, and IP-range hardening fixes.
 
-- Es wird ein eindeutiger Name für das Sitzungs-Cookie (\`i_like_gitea\`) anstelle des generischen \`session\` verwendet, um Anmeldefehler zu vermeiden, wenn andere Dienste denselben lokalen Hostnamen nutzen. Nach dem Update musst du dich möglicherweise erneut anmelden.`,
-    pl_PL: `**Ulepszenia**
+**Breaking**
 
-- Używana jest unikalna nazwa ciasteczka sesji (\`i_like_gitea\`) zamiast ogólnej \`session\`, co zapobiega błędom logowania, gdy inne usługi współdzielą tę samą lokalną nazwę hosta. Po aktualizacji może być konieczne ponowne zalogowanie.`,
-    fr_FR: `**Améliorations**
+- Gitea Actions now requires a merged PR to bypass the fork PR approval gate.
 
-- Utilisation d'un nom unique pour le cookie de session (\`i_like_gitea\`) au lieu du générique \`session\`, évitant les erreurs de connexion lorsque d'autres services partagent le même nom d'hôte local. Vous devrez peut-être vous reconnecter après la mise à jour.`,
+**Fixes**
+
+- Resolves the "context deadline exceeded" regression from 1.26.3 when opening repository code pages, plus numerous other bug fixes.
+
+Full notes: https://github.com/go-gitea/gitea/releases/tag/v1.26.4`,
+    es_ES: `Gitea actualizado a 1.26.4.
+
+**Seguridad**
+
+- Los usuarios deshabilitados ya no se reactivan automáticamente al iniciar sesión con OAuth2, además de varias mejoras de seguridad en LFS, el comparador de hosts y los rangos de IP.
+
+**Cambios importantes**
+
+- Gitea Actions ahora requiere un PR fusionado para omitir la verificación de aprobación de PR de bifurcaciones.
+
+**Correcciones**
+
+- Soluciona la regresión "context deadline exceeded" de la 1.26.3 al abrir las páginas de código de un repositorio, junto con numerosas correcciones de errores.
+
+Notas completas: https://github.com/go-gitea/gitea/releases/tag/v1.26.4`,
+    de_DE: `Gitea auf 1.26.4 aktualisiert.
+
+**Sicherheit**
+
+- Deaktivierte Benutzer werden bei der OAuth2-Anmeldung nicht mehr automatisch reaktiviert, dazu mehrere Härtungsfixes für LFS, den Host-Matcher und IP-Bereiche.
+
+**Wichtige Änderungen**
+
+- Gitea Actions erfordert nun einen zusammengeführten PR, um die Genehmigungsprüfung für Fork-PRs zu umgehen.
+
+**Fehlerbehebungen**
+
+- Behebt die Regression "context deadline exceeded" aus 1.26.3 beim Öffnen der Code-Seiten eines Repositorys sowie zahlreiche weitere Fehlerbehebungen.
+
+Vollständige Hinweise: https://github.com/go-gitea/gitea/releases/tag/v1.26.4`,
+    pl_PL: `Zaktualizowano Gitea do 1.26.4.
+
+**Bezpieczeństwo**
+
+- Wyłączeni użytkownicy nie są już automatycznie ponownie aktywowani podczas logowania OAuth2, a także kilka poprawek zabezpieczeń dla LFS, dopasowywania hostów i zakresów IP.
+
+**Zmiany niekompatybilne**
+
+- Gitea Actions wymaga teraz scalonego PR, aby ominąć bramkę zatwierdzania PR z forka.
+
+**Poprawki**
+
+- Naprawia regresję "context deadline exceeded" z wersji 1.26.3 przy otwieraniu stron z kodem repozytorium oraz wiele innych błędów.
+
+Pełne informacje: https://github.com/go-gitea/gitea/releases/tag/v1.26.4`,
+    fr_FR: `Gitea mis à jour vers 1.26.4.
+
+**Sécurité**
+
+- Les utilisateurs désactivés ne sont plus réactivés automatiquement lors de la connexion OAuth2, ainsi que plusieurs correctifs de sécurité pour LFS, le comparateur d'hôtes et les plages d'IP.
+
+**Changements majeurs**
+
+- Gitea Actions exige désormais une PR fusionnée pour contourner le contrôle d'approbation des PR de forks.
+
+**Corrections**
+
+- Corrige la régression « context deadline exceeded » de la 1.26.3 lors de l'ouverture des pages de code d'un dépôt, ainsi que de nombreux autres correctifs.
+
+Notes complètes: https://github.com/go-gitea/gitea/releases/tag/v1.26.4`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps Gitea from **1.26.2** to **1.26.4** (`gitea/gitea` Docker tag in `startos/manifest/index.ts`). StartOS version `1.26.2:1` → `1.26.4:0`.

start-sdk is already at the latest npm release (1.5.3); `npm update` refreshed transitive deps only.

## Upstream highlights (1.26.3 + 1.26.4)

- **Security:** disabled users no longer auto-reactivated on OAuth2 login; LFS auth-bypass fixes; host-matcher / reserved-IP-range hardening; `golang.org/x/net` security bump.
- **Breaking:** Gitea Actions now requires a merged PR to bypass the fork PR approval gate.
- **Fixes:** 1.26.4 resolves the "context deadline exceeded" regression introduced in 1.26.3 when opening repository code pages, plus numerous other bug fixes.

Full notes: https://github.com/go-gitea/gitea/releases/tag/v1.26.4 · https://github.com/go-gitea/gitea/releases/tag/v1.26.3

## Notes

- No new/changed actions, ports, interfaces, volumes, or dependencies — README and instructions unchanged.
- No migration required; `current.ts` edited in place (existing legacy-config migration retained).

## Test plan

- `npm run check` (tsc --noEmit) — green.
- Full `make` / s9pk verification in review.